### PR TITLE
Homepage fixes: button contrast and partner section

### DIFF
--- a/themes/hugo-bulma-blocks-theme/assets/css/homepage.css
+++ b/themes/hugo-bulma-blocks-theme/assets/css/homepage.css
@@ -295,6 +295,37 @@
     border-color: var(--white);
 }
 
+/* Hero CTA Buttons - High contrast for hero background */
+.hero-ctas .button.is-primary:not(.is-outlined) {
+    background: var(--accent) !important;
+    background-color: var(--accent) !important;
+    border-color: var(--accent) !important;
+    color: var(--white) !important;
+    box-shadow: 0 4px 20px rgba(232, 163, 49, 0.4);
+    font-weight: 700;
+}
+
+.hero-ctas .button.is-primary:not(.is-outlined):hover {
+    background: var(--accent-dark) !important;
+    background-color: var(--accent-dark) !important;
+    border-color: var(--accent-dark) !important;
+    transform: translateY(-2px);
+    box-shadow: 0 6px 28px rgba(232, 163, 49, 0.5);
+}
+
+.hero-ctas .button.is-outlined.is-primary {
+    background: transparent !important;
+    border: 2px solid rgba(255, 255, 255, 0.9) !important;
+    color: var(--white) !important;
+    font-weight: 700;
+}
+
+.hero-ctas .button.is-outlined.is-primary:hover {
+    background: rgba(255, 255, 255, 0.15) !important;
+    border-color: var(--white) !important;
+    color: var(--white) !important;
+}
+
 /* Hero Visual / Image */
 .hero-visual {
     display: flex;

--- a/themes/hugo-bulma-blocks-theme/layouts/index.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/index.html
@@ -5,7 +5,6 @@
 {{/* Banner replaced by hero section in explore.html for homepage redesign */}}
 {{ .Content }}
 {{ partial "explore.html" . }}
-{{ partial "funders-simple.html" . }}
 
 {{ if .Page.File }}
 <section class="section pt-0 is-hidden-touch">

--- a/themes/hugo-bulma-blocks-theme/layouts/partials/explore.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/partials/explore.html
@@ -203,22 +203,22 @@
 <section class="section trust-bar">
     <div class="container">
         <a href="{{ absURL "partners/" }}" class="trust-bar-link">
-            <p class="trust-text has-text-centered">Trusted by organisations worldwide</p>
+            <p class="trust-text has-text-centered">Our Partners</p>
             <div class="trust-logos columns is-mobile is-multiline is-centered is-vcentered">
                 <div class="column is-narrow">
-                    <span class="trust-item"><img src="{{ absURL "img/logo-wb-header-en.svg" }}" alt="World Bank" style="max-width: 120px; max-height: 80px; object-fit: contain;"></span>
+                    <a href="https://app.qfield.cloud/accounts/signup/?fpr=tim39" target="_blank" rel="noopener" class="trust-item has-text-weight-bold is-size-4">QField</a>
                 </div>
                 <div class="column is-narrow">
-                    <span class="trust-item"><img src="{{ absURL "img/logo-unicef.png" }}" alt="UNICEF" style="max-width: 120px; max-height: 80px; object-fit: contain;"></span>
+                    <a href="https://merginmaps.com/" target="_blank" rel="noopener" class="trust-item has-text-weight-bold is-size-4">Mergin Maps</a>
                 </div>
                 <div class="column is-narrow">
-                    <span class="trust-item"><img src="{{ absURL "img/logo-wwf.png" }}" alt="WWF" style="max-width: 120px; max-height: 80px; object-fit: contain;"></span>
+                    <a href="https://www.landinfotech.com/" target="_blank" rel="noopener" class="trust-item has-text-weight-bold is-size-4">LandInfo Technologies</a>
                 </div>
                 <div class="column is-narrow">
-                    <span class="trust-item"><img src="{{ absURL "img/logo-sanparks.png" }}" alt="SANParks" style="max-width: 120px; max-height: 80px; object-fit: contain;"></span>
+                    <a href="https://www.eointelligence.ca/" target="_blank" rel="noopener" class="trust-item has-text-weight-bold is-size-4">EO Intelligence</a>
                 </div>
                 <div class="column is-narrow">
-                    <span class="trust-item"><img src="{{ absURL "img/logo-ihe.svg" }}" alt="IHE Delft" style="max-width: 120px; max-height: 80px; object-fit: contain;"></span>
+                    <a href="https://www.giswater.org/" target="_blank" rel="noopener" class="trust-item has-text-weight-bold is-size-4">Giswater</a>
                 </div>
             </div>
             <p class="trust-cta has-text-centered">


### PR DESCRIPTION
## Summary
- Fix hero CTA button contrast for better visibility against blue background
- Replace customer logos (World Bank, UNICEF, etc.) with actual partner links
- Partners now displayed as text links: QField, Mergin Maps, LandInfo Technologies, EO Intelligence, Giswater
- QField uses affiliate signup link
- Remove empty funders block from homepage

## Test plan
- [x] Verify hero buttons are visible with high contrast (orange primary, white outlined)
- [x] Verify partner links work and open in new tabs
- [x] Verify QField affiliate link is correct
- [x] Verify empty funders section is removed from bottom of page