### PR TITLE
fix: move redirects.conf out of conf.d to prevent nginx startup failure

### DIFF
--- a/deployment/docker/entrypoint.sh
+++ b/deployment/docker/entrypoint.sh
@@ -43,7 +43,7 @@ export gateway_erpnext_api_url="${GATEWAY_ERPNEXT_API_URL}"
 envsubst '${erpnext_api_auth_base64} ${gateway_erpnext_api_url}' < /etc/nginx/templates/default.conf.template > /tmp/nginx/conf.d/default.conf
 
 # Copy redirect rules (no envsubst needed - static config)
-cp /etc/nginx/templates/redirects.conf /tmp/nginx/conf.d/redirects.conf
+cp /etc/nginx/templates/redirects.conf /tmp/nginx/redirects.conf
 
 echo "Starting nginx..."
 

--- a/deployment/nginx/sites-enabled/default.conf
+++ b/deployment/nginx/sites-enabled/default.conf
@@ -43,7 +43,7 @@ server {
     # Legacy URL Redirects
     # All redirect rules are maintained in redirects.conf
     # ==========================================================================
-    include /tmp/nginx/conf.d/redirects.conf;
+    include /tmp/nginx/redirects.conf;
 
     # Health check endpoint
     location /health {


### PR DESCRIPTION
## Summary
- **Fixed nginx startup crash** caused by `redirects.conf` being loaded at the `http` block level via the wildcard `include /tmp/nginx/conf.d/*.conf`
- `rewrite` and `location` directives in `redirects.conf` are only valid inside a `server` block, so the file is now copied to `/tmp/nginx/redirects.conf` instead of `/tmp/nginx/conf.d/redirects.conf`
- Updated the include path in `default.conf` to match

## Root cause
The entrypoint script copied `redirects.conf` into `/tmp/nginx/conf.d/`, where `nginx.conf`'s wildcard include (`*.conf`) loaded it at the `http` level — in addition to the intended include inside the `server` block in `default.conf`. This caused:
```
"rewrite" directive is not allowed here in /tmp/nginx/conf.d/redirects.conf:23
```

## Test plan
- [ ] Build and run the Docker container — nginx should start without errors
- [ ] Verify legacy URL redirects still work (e.g. `/blog/python/some-post` → `/blog/some-post/`)
- [ ] Verify `/health` endpoint returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)