### PR TITLE
Remove internships menu item and update internships page to draft status

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -176,12 +176,6 @@ matomoSiteId = ''
   url = "/careers/"
   weight = 40
 
-[[menu.main]]
-  parent = "About"
-  name = "Internships"
-  url = "/internships/"
-  weight = 50
-
 # -- Our Work (dropdown) --
 [[menu.main]]
   name = "Our Work"

--- a/content/internships/index.md
+++ b/content/internships/index.md
@@ -4,4 +4,6 @@ title: "Internships"
 subtitle: "Launch your GIS career with Kartoza"
 layout: "single"
 draft: true
+reviewedBy: "Moloko Mokubedi"
+reviewedDate: 2026-05-19
 ---

--- a/content/internships/index.md
+++ b/content/internships/index.md
@@ -3,4 +3,5 @@ type: "internships"
 title: "Internships"
 subtitle: "Launch your GIS career with Kartoza"
 layout: "single"
+draft: true
 ---


### PR DESCRIPTION
This pull request makes small but important updates related to the internships section of the site. The main change is the removal of the "Internships" menu item from the main navigation, and some metadata updates to the internships page.

- Navigation changes:
  * Removed the "Internships" link from the main navigation menu in `config.toml`.

- Content metadata updates:
  * Marked the `content/internships/index.md` page as a draft, and added reviewer information and a reviewed date.<!-- Make a "Fixes #" line for each issue you want to close -->
Fixes #

### Summary of the Fixes
<!-- Include a short description for each of the changes made. This will help the reviewer -->
