### PR TITLE
Add Google AdSense support to blog layout

### DIFF
--- a/deployment/nginx/sites-enabled/default.conf
+++ b/deployment/nginx/sites-enabled/default.conf
@@ -36,8 +36,8 @@ server {
     # Permissions policy - restrict browser features
     add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
 
-    # Content Security Policy - allow self, inline styles/scripts (required by Hugo), YouTube embeds, and gallery map embeds
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.youtube.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; frame-src https://www.youtube.com https://www.youtube-nocookie.com https://maps.kartoza.com; child-src https://www.youtube.com https://www.youtube-nocookie.com https://maps.kartoza.com; connect-src 'self'; base-uri 'self'; form-action 'self';" always;
+    # Content Security Policy - allow self, inline styles/scripts (required by Hugo), YouTube embeds, gallery map embeds, and Google AdSense
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.youtube.com https://pagead2.googlesyndication.com https://partner.googleadservices.com https://tpc.googlesyndication.com https://www.googletagservices.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; frame-src https://www.youtube.com https://www.youtube-nocookie.com https://maps.kartoza.com https://googleads.g.doubleclick.net https://tpc.googlesyndication.com; child-src https://www.youtube.com https://www.youtube-nocookie.com https://maps.kartoza.com https://googleads.g.doubleclick.net https://tpc.googlesyndication.com; connect-src 'self' https://pagead2.googlesyndication.com https://googleads.g.doubleclick.net; base-uri 'self'; form-action 'self';" always;
 
     # ==========================================================================
     # Legacy URL Redirects

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -118,12 +118,12 @@
                     </div>
                 </div>
 
-                <!--Google AdSense Code-->
+                <!-- Google AdSense -->
                 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4905598657746318"
                 crossorigin="anonymous"></script>
                 <!-- Square Ads -->
                 <ins class="adsbygoogle"
-                style="display:block"
+                style="display:block;margin-bottom:1.5rem;"
                 data-ad-client="ca-pub-4905598657746318"
                 data-ad-slot="3751362148"
                 data-ad-format="auto"


### PR DESCRIPTION
Fixes #

### Summary of the Fixes
Integrate Google AdSense into the blog layout and update the Content Security Policy to allow necessary scripts and resources for ads.

